### PR TITLE
Refactor to checking for root with uid instead of username

### DIFF
--- a/dnf_reinstall.sh
+++ b/dnf_reinstall.sh
@@ -27,7 +27,7 @@ case "$1" in
 esac
 
 # If the script isn't run with sudo / root privileges, quit.
-if [[ $(whoami) != 'root' ]]; then
+if [[ "$EUID" != "0" ]]; then
 	printf '\n%s\n\n' 'You need to be root to run this script!'
 	exit
 fi

--- a/dup_dir_ln.sh
+++ b/dup_dir_ln.sh
@@ -25,7 +25,7 @@ usage () {
 }
 
 # If the script isn't run with sudo / root privileges, then quit.
-if [[ $(whoami) != 'root' ]]; then
+if [[ "$EUID" != "0" ]]; then
 	printf '\n%s\n\n' 'You need to be root to run this script!'
 	exit
 fi

--- a/flash_usb.sh
+++ b/flash_usb.sh
@@ -15,7 +15,7 @@ if [[ ! -f $1 ]]; then
 fi
 
 # If the script isn't run with sudo / root privileges, then quit.
-if [[ $(whoami) != 'root' ]]; then
+if [[ "$EUID" != "0" ]]; then
 	printf '\n%s\n\n' 'You need to be root to run this script!'
 	exit
 fi

--- a/format_lowlevel.sh
+++ b/format_lowlevel.sh
@@ -13,7 +13,7 @@ if [[ $# -eq 0 ]]; then
 fi
 
 # If the script isn't run with sudo / root privileges, then quit.
-if [[ $(whoami) != 'root' ]]; then
+if [[ "$EUID" != "0" ]]; then
 	printf '\n%s\n\n' 'You need to be root to run this script!'
 	exit
 fi

--- a/fuck_your_system_up.sh
+++ b/fuck_your_system_up.sh
@@ -5,7 +5,7 @@
 # permanently delete all your files on every device. Do NOT run this!
 
 # If the script isn't run with sudo / root privileges, quit.
-if [[ $(whoami) != 'root' ]]; then
+if [[ "$EUID" != "0" ]]; then
 	printf '\n%s\n\n' 'You need to be root to run this script!'
 	exit
 fi

--- a/hdd_dump.sh
+++ b/hdd_dump.sh
@@ -34,7 +34,7 @@ usage () {
 }
 
 # If the script isn't run with sudo / root privileges, then quit.
-if [[ $(whoami) != 'root' ]]; then
+if [[ "$EUID" != "0" ]]; then
 	printf '\n%s\n\n' 'You need to be root to run this script!'
 	exit
 fi

--- a/reformat_script.sh
+++ b/reformat_script.sh
@@ -37,7 +37,7 @@ switch='0'
 set -eo pipefail
 
 # If the script isn't run with sudo / root privileges, quit.
-if [[ $(whoami) != 'root' ]]; then
+if [[ "$EUID" != "0" ]]; then
 	printf '\n%s\n\n' "You need to be root to run this script!"
 	exit
 fi

--- a/rm_old_kernels.sh
+++ b/rm_old_kernels.sh
@@ -5,7 +5,7 @@
 # each kernel package, and removes all the older versions.
 
 # If the script isn't run with sudo / root privileges, quit.
-if [[ $(whoami) != 'root' ]]; then
+if [[ "$EUID" != "0" ]]; then
 	printf '\n%s\n\n' 'You need to be root to run this script!'
 	exit
 fi


### PR DESCRIPTION
The scripts seem to be using `[[ $(whoami) != 'root' ]]` pattern to check if the user is root:
```bash
$ find "$(git rev-parse --show-toplevel)" -type f -exec grep -nHF '[[ $(whoami) != '\''root'\'' ]]' {} +
.../rm_old_kernels.sh:8:if [[ $(whoami) != 'root' ]]; then
.../hdd_dump.sh:37:if [[ $(whoami) != 'root' ]]; then
.../fuck_your_system_up.sh:8:if [[ $(whoami) != 'root' ]]; then
.../reformat_script.sh:40:if [[ $(whoami) != 'root' ]]; then
.../dnf_reinstall.sh:30:if [[ $(whoami) != 'root' ]]; then
.../dup_dir_ln.sh:28:if [[ $(whoami) != 'root' ]]; then
.../format_lowlevel.sh:16:if [[ $(whoami) != 'root' ]]; then
.../flash_usb.sh:18:if [[ $(whoami) != 'root' ]]; then
```

`root` as user with most privilidges is a convention, and nothing is stopping me from changing it to something like `admin`, which would break all the scripts checking for root privs.

What makes root root is user id, which always stays the same, and if it's 0, then it's root no mater the name.

```bash
perl -i -p -e 's/\Q[[ $(whoami) != '\''root'\'' ]]\E/[[ "\$EUID" != "0" ]]/g' *.sh
```

This would also eliminate additional calls to external `whoami`, which is a GNU utility.